### PR TITLE
fix syntax to be compatible with python 3.5

### DIFF
--- a/pyhive/sqlalchemy_presto.py
+++ b/pyhive/sqlalchemy_presto.py
@@ -77,7 +77,7 @@ class PrestoCompiler(SQLCompiler):
             return sql
 
         catalog = table.dialect_options["presto"]._non_defaults["catalog"]
-        sql = f"\"{catalog}\".{sql}"
+        sql = "\"{catalog}\".{sql}".format(catalog=catalog, sql=sql)
         return sql
 
 


### PR DESCRIPTION
This is the same line that causes tests to fail in python 3.4 and 3.5. Python 2.7 has different failures not covered in this PR.