### PR TITLE
Fix python 2.7 and 3.4/5 syntax

### DIFF
--- a/pyhive/presto.py
+++ b/pyhive/presto.py
@@ -41,7 +41,7 @@ class PrestoParamEscaper(common.ParamEscaper):
         elif isinstance(item, datetime.date):
             return self.escape_date(item)
         else:
-            return super().escape_item(item)
+            return super(PrestoParamEscaper, self).escape_item(item)
 
     def escape_date(self, item):
         return "date '{}'".format(item)

--- a/pyhive/sqlalchemy_presto.py
+++ b/pyhive/sqlalchemy_presto.py
@@ -77,7 +77,7 @@ class PrestoCompiler(SQLCompiler):
             return sql
 
         catalog = table.dialect_options["presto"]._non_defaults["catalog"]
-        sql = f"\"{catalog}\".{sql}"
+        sql = "\"{catalog}\".{sql}".format(catalog=catalog, sql=sql)
         return sql
 
 

--- a/pyhive/sqlalchemy_presto.py
+++ b/pyhive/sqlalchemy_presto.py
@@ -63,7 +63,7 @@ class PrestoCompiler(SQLCompiler):
         )
         return self.__add_catalog(sql, table)
 
-    def __add_catalog(self, sql: str, table: FromClause) -> str:
+    def __add_catalog(self, sql, table):
         if table is None:
             return sql
 


### PR DESCRIPTION
update syntax errors for python 2.7. Branched off of python 3.5 syntax fix, so it supersedes other PR.